### PR TITLE
Fix example OPENSEARCH_HOST in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ return [
     ...
 
     'opensearch' => [
-        'host' => env('OPENSEARCH_HOST', 'http://localhost:9200'),
+        'host' => env('OPENSEARCH_HOST', 'https://localhost:9200'),
         'access_key' => env('OPENSEARCH_ACCESS_KEY', 'admin'),
         'secret_key' => env('OPENSEARCH_SECRET_KEY', 'admin'),
         'options' => [


### PR DESCRIPTION
Opensearch wasn't happy unless I used TLS with it, changing the protocol to `https` fixed it.