### PR TITLE
Add support for Laravel Scout 'where' clauses

### DIFF
--- a/src/Engines/OpenSearchEngine.php
+++ b/src/Engines/OpenSearchEngine.php
@@ -108,10 +108,12 @@ class OpenSearchEngine extends \Laravel\Scout\Engines\Engine
             );
         }
 
+        $filters = $this->filters($builder);
+
         return $this->openSearch->search(
             $index,
             $builder->query,
-            $options
+            array_merge_recursive($options, $filters),
         );
     }
 
@@ -175,6 +177,25 @@ class OpenSearchEngine extends \Laravel\Scout\Engines\Engine
         })->sortBy(function ($model) use ($objectIdPositions) {
             return $objectIdPositions[$model->getScoutKey()];
         })->values();
+    }
+
+    protected function filters(Builder $builder): array
+    {
+        if(empty($builder->wheres)) {
+            return [];
+        }
+
+        return [
+            'body' => [
+                'query' => [
+                    'bool' => [
+                        'filter' => [
+                            ['term' =>  $builder->wheres]
+                        ]
+                    ]
+                ]
+            ]
+        ];
     }
 
     public function getTotalCount($results)

--- a/src/Services/OpenSearchClient.php
+++ b/src/Services/OpenSearchClient.php
@@ -64,17 +64,23 @@ class OpenSearchClient
 
     public function search(string $index, string $query, array $options = [])
     {
-        return $this->client->search(array_merge([
+        $params = array_merge_recursive([
             'index' => $index,
-            'body'  => [
-                'size'  => 1000,
+            'body' => [
+                'size' => 1000,
                 'query' => [
-                    'simple_query_string' => [
-                        'query'            => "$query* | \"$query\"",
-                        'default_operator' => 'and'
-                    ],
+                    'bool' => [
+                        'must' => [
+                            'simple_query_string' => [
+                                'query' => "$query* | \"$query\"",
+                                'default_operator' => 'and'
+                            ],
+                        ]
+                    ]
                 ],
             ],
-        ], $options));
+        ], $options);
+
+        return $this->client->search($params);
     }
 }

--- a/tests/Feature/SearchTest.php
+++ b/tests/Feature/SearchTest.php
@@ -10,7 +10,7 @@ beforeEach(function () {
         (new \OpenSearch\ClientBuilder())
             ->setHosts(["https://127.0.0.1:9200"])
             ->setSSLVerification(false)
-            ->setBasicAuthentication("admin", "admin")
+            ->setBasicAuthentication("admin", "oDLx8Bfs4G86")
             ->build()
     );
     $this->engine = new OpenSearchEngine($this->openSearch);
@@ -90,4 +90,12 @@ it('can search by house number', function () {
     $count = $this->engine->getTotalCount($this->openSearch->search($this->index, "456"));
 
     expect($count)->toBe(1);
+});
+
+it('can search with a scout where clause', function () {
+    $builder = new \Laravel\Scout\Builder(stdClass::class, 'Isle');
+    $builder->index = $this->index;
+    $builder->where('rating', 5);
+    $results = $this->engine->search($builder);
+    expect($results['hits']['total']['value'])->toBe(2);
 });

--- a/tests/data/documents.json
+++ b/tests/data/documents.json
@@ -1,7 +1,7 @@
 [
-  { "objectID": 1, "name": "Greenwood Paper Factory", "address_line_1": "123 Shore road", "address_postcode": "AX1 BT2", "email": "greenwood+email@example.com" },
-  { "objectID": 2, "name": "Blackwood Paper Factory", "address_line_1": "456 London street", "address_postcode": "TY8 XC3", "email": "blackwood+email@example.com" },
-  { "objectID": 3, "name": "Isle of Green Company", "address_line_1": "756 Brussels avenue", "address_postcode": "HY7 TJ8", "email": "info@isleofgreen.com" },
-  { "objectID": 4, "name": "Isle of Purple Company", "address_line_1": "7 Purple avenue", "address_postcode": "XV1 KI9", "email": "info@iop.com" },
-  { "objectID": 5, "name": "True storage solutions", "address_line_1": "Isle of green", "address_postcode": "UI8 GH5", "email": "help@truestoragesolutions.co.uk" }
+  { "objectID": 1, "name": "Greenwood Paper Factory", "address_line_1": "123 Shore road", "address_postcode": "AX1 BT2", "email": "greenwood+email@example.com", "rating": 1 },
+  { "objectID": 2, "name": "Blackwood Paper Factory", "address_line_1": "456 London street", "address_postcode": "TY8 XC3", "email": "blackwood+email@example.com", "rating": 5},
+  { "objectID": 3, "name": "Isle of Green Company", "address_line_1": "756 Brussels avenue", "address_postcode": "HY7 TJ8", "email": "info@isleofgreen.com", "rating": 5 },
+  { "objectID": 4, "name": "Isle of Purple Company", "address_line_1": "7 Purple avenue", "address_postcode": "XV1 KI9", "email": "info@iop.com", "rating": 5 },
+  { "objectID": 5, "name": "True storage solutions", "address_line_1": "Isle of green", "address_postcode": "UI8 GH5", "email": "help@truestoragesolutions.co.uk", "rating": 2 }
 ]


### PR DESCRIPTION
This PR facilitates where clauses on Opensearch by using the filter by term parameters.  In order to do this I needed to refactor the search to use a 'bool' and a 'must'. This shouldn't have any impact on other query results.